### PR TITLE
Thêm chức năng quên mật khẩu  & reset password

### DIFF
--- a/backend/backend-auth/utils/cloudinary.js
+++ b/backend/backend-auth/utils/cloudinary.js
@@ -1,0 +1,12 @@
+import { v2 as cloudinary } from "cloudinary";
+import dotenv from "dotenv";
+
+dotenv.config({ path: "../.env" });
+
+cloudinary.config({
+  cloud_name: process.env.CLOUDINARY_NAME, // 👈 đổi dòng này
+  api_key: process.env.CLOUDINARY_API_KEY,
+  api_secret: process.env.CLOUDINARY_API_SECRET,
+});
+
+export default cloudinary;

--- a/backend/backend-auth/utils/sendEmail.js
+++ b/backend/backend-auth/utils/sendEmail.js
@@ -1,0 +1,33 @@
+import nodemailer from "nodemailer";
+
+const sendEmail = async (to, subject, html) => {
+  try {
+    console.log("📨 Đang gửi mail tới:", to);
+
+    const transporter = nodemailer.createTransport({
+      host: "smtp.gmail.com",
+      port: 465,
+      secure: true,
+      auth: {
+        user: process.env.EMAIL_USER,
+        pass: process.env.EMAIL_PASS,
+      },
+      tls: {
+        rejectUnauthorized: false, // ⚠️ thêm dòng này
+      },
+    });
+
+    const info = await transporter.sendMail({
+      from: `"Group16 Support" <${process.env.EMAIL_USER}>`,
+      to,
+      subject,
+      html,
+    });
+
+    console.log("✅ Email gửi thành công:", info.messageId);
+  } catch (err) {
+    console.error("❌ Lỗi gửi email:", err);
+  }
+};
+
+export default sendEmail;


### PR DESCRIPTION
## 🧩 Hoạt động 4 – Quên mật khẩu & Đặt lại mật khẩu

**Nhóm:** 16  
**Sinh viên phụ trách:**
- **SV1:** Backend  
- **SV2:** Frontend  
- **SV3:** Database  

---

### 🔧 Backend (SV1)
- Thêm 2 API chính:
  - `POST /api/auth/forgot-password`: gửi email chứa token đặt lại mật khẩu bằng **Nodemailer** và Gmail App Password.  
  - `POST /api/auth/reset-password/:token`: xác thực token và cập nhật mật khẩu mới (hash bằng **bcrypt**).
- Cập nhật `User` schema:
  ```js
  resetPasswordToken: String,
  resetPasswordExpire: Date,